### PR TITLE
Conditional error

### DIFF
--- a/src/renderer/components/Task.tsx
+++ b/src/renderer/components/Task.tsx
@@ -842,7 +842,7 @@ function Task({ task, goBack }: TaskProps) {
                   (step === 'LOCAL_DATA' && !file?.path) ||
                   isRunning ||
                   (step === 'STAKE' &&
-                    Number(dataStakedBalance) < stake * 10 ** 18)
+                    Number(dataStakedBalance) < task.stake * 10 ** 18)
                 }
                 onClick={nextStep}
               />


### PR DESCRIPTION
When user sets stake to <= 0 without actually staking tokens, next step button activates and users can move to the next step without staking the tokens